### PR TITLE
Fix string/array issue in prometheus.yml.erb. Support for wrapper cookbook with LWRP and set alert rules files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The following cookbooks are dependencies:
 
 ### prometheus::default
 
-Include `prometheus` in your node's `run_list`:
+Include `prometheus` in your node's `run_list` to execute the standard deployment of prometheus:
 
 ```json
 {
@@ -98,6 +98,40 @@ Include `prometheus` in your node's `run_list`:
     "recipe[prometheus::default]"
   ]
 }
+```
+
+### prometheus::use_lwrp
+
+Used to load promethus cookbook from wrapper cookbook.
+
+`prometheus::use_lwrp` doesn't do anything other than allow you to include the
+Prometheus cookbook into your wrapper or app cookbooks. Doing this allows you to
+override prometheus attributes and use the prometheus LWRP (`prometheus_job`) in
+your wrapper cookbooks.
+
+```ruby
+# Load the promethues cookbook into your wrapper so you have access to the LWRP and attributes
+
+include_recipe "prometheus::use_lwrp"
+
+# Change the default top level directory for prometheus install as an example of attribute overrides
+node.set['prometheus']['dir'] = '/usr/local/prometheus'
+
+# Example of using search to populate prometheus.yaml jobs using the prometheus_job LWRP
+# Finds all the instances that are in the current environment and are taged with "node_exporter"
+# Assumes that the service instances were tagged in their own recipes.
+client_servers = search(:node, "environment:#{node.chef_environment} AND tags:node_exporter")
+
+# Assumes service_name is an attribute of each node
+client_servers.each do |server|
+	prometheus_job server.service_name do
+  	  scrape_interval   ‘15s’
+	  target            “http://#{server.fqdn}#{node[‘prometheus’][‘flags’][‘web.listen-address’]}#{node[‘prometheus’][‘flags’][‘web.telemetry-path’]}”
+	end
+end
+
+# Now run the default recipe that does all the work configuring and deploying prometheus
+include_recipe "prometheus::default"
 ```
 
 Development

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ your wrapper cookbooks.
 
 include_recipe "prometheus::use_lwrp"
 
-# Change the default top level directory for prometheus install as an example of attribute overrides
-node.set['prometheus']['dir'] = '/usr/local/prometheus'
+# Add a rule filename under `rule_files` in prometheus.yml.erb
+node.set['prometheus']['rule_filenames'] = ["#{node['prometheus']['dir']}/alert.rules"]
 
 # Example of using search to populate prometheus.yaml jobs using the prometheus_job LWRP
 # Finds all the instances that are in the current environment and are taged with "node_exporter"
@@ -126,7 +126,8 @@ client_servers = search(:node, "environment:#{node.chef_environment} AND tags:no
 client_servers.each do |server|
 	prometheus_job server.service_name do
   	  scrape_interval   ‘15s’
-	  target            “http://#{server.fqdn}#{node[‘prometheus’][‘flags’][‘web.listen-address’]}#{node[‘prometheus’][‘flags’][‘web.telemetry-path’]}”
+	  target            “#{server.fqdn}#{node[‘prometheus’][‘flags’][‘web.listen-address’]}"
+	  metric_path       "#{node[‘prometheus’][‘flags’][‘web.telemetry-path’]}”
 	end
 end
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -227,3 +227,6 @@ default['prometheus']['alertmanager']['hipchat_auth_token']                     
 
 # Room ID to use when Alertmanager notifies HipChat
 default['prometheus']['alertmanager']['hipchat_room_id']                                  = 123456
+
+# Array of alert rules filenames to be inserted in prometheus.yml.erb under "rule_files"
+default['prometheus']['rule_filenames']                                                   = nil

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -82,6 +82,7 @@ default['prometheus']['job_config_cookbook_name']                               
 # generate the command line flags for the Prometheus executable.
 
 # Prometheus configuration file name.
+
 default['prometheus']['flags']['config.file']                                             = "#{node['prometheus']['dir']}/prometheus.yml"
 
 # Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal, panic].
@@ -230,3 +231,6 @@ default['prometheus']['alertmanager']['hipchat_room_id']                        
 
 # Array of alert rules filenames to be inserted in prometheus.yml.erb under "rule_files"
 default['prometheus']['rule_filenames']                                                   = nil
+
+
+default['prometheus']['alertmanager']['notification'] = {}

--- a/recipes/alertmanager.rb
+++ b/recipes/alertmanager.rb
@@ -48,6 +48,9 @@ template node['prometheus']['alertmanager']['config.file'] do
   mode      0644
   owner     node['prometheus']['user']
   group     node['prometheus']['group']
+  variables(
+    notification_config: node['prometheus']['alertmanager']['notification']
+  )
   notifies  :restart, 'service[alertmanager]'
 end
 
@@ -76,10 +79,6 @@ template '/etc/init/alertmanager.conf' do
   source 'upstart/alertmanager.service.erb'
   mode 0644
   notifies :restart, 'service[alertmanager]', :delayed
-  variables(
-    notification_config: node['prometheus']['alertmanager']['notification']
-  )
-  notifies  :restart, 'service[alertmanager]'
 end
 
 service 'alertmanager' do

--- a/recipes/alertmanager.rb
+++ b/recipes/alertmanager.rb
@@ -71,10 +71,15 @@ bash 'compile_alertmanager_source' do
   notifies :restart, 'service[alertmanager]'
 end
 
+
 template '/etc/init/alertmanager.conf' do
   source 'upstart/alertmanager.service.erb'
   mode 0644
   notifies :restart, 'service[alertmanager]', :delayed
+  variables(
+    notification_config: node['prometheus']['alertmanager']['notification']
+  )
+  notifies  :restart, 'service[alertmanager]'
 end
 
 service 'alertmanager' do

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,7 +47,7 @@ template node['prometheus']['flags']['config.file'] do
   owner     node['prometheus']['user']
   group     node['prometheus']['group']
   variables(
-    :rule_filenames => node['prometheus']['rule_filenames']
+    rule_filenames: node['prometheus']['rule_filenames']
   )
   notifies  :restart, 'service[prometheus]'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,8 +39,6 @@ end
 
 # -- Write our Config -- #
 
-Chef::Log.info "^^^^^^^^^ node['prometheus']['rule_filenames']: #{node['prometheus']['rule_filenames'].inspect}"
-
 template node['prometheus']['flags']['config.file'] do
   action    :nothing
   cookbook  node['prometheus']['job_config_cookbook_name']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,8 @@ end
 
 # -- Write our Config -- #
 
+Chef::Log.info "^^^^^^^^^ node['prometheus']['rule_filenames']: #{node['prometheus']['rule_filenames'].inspect}"
+
 template node['prometheus']['flags']['config.file'] do
   action    :nothing
   cookbook  node['prometheus']['job_config_cookbook_name']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,7 +49,7 @@ template node['prometheus']['flags']['config.file'] do
   owner     node['prometheus']['user']
   group     node['prometheus']['group']
   variables(
-    rule_filenames: node['prometheus']['rule_filenames']
+    :rule_filenames => node['prometheus']['rule_filenames']
   )
   notifies  :restart, 'service[prometheus]'
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -46,6 +46,9 @@ template node['prometheus']['flags']['config.file'] do
   mode      0644
   owner     node['prometheus']['user']
   group     node['prometheus']['group']
+  variables(
+    rule_filenames: node['prometheus']['rule_filenames']
+  )
   notifies  :restart, 'service[prometheus]'
 end
 

--- a/recipes/use_lwrp.rb
+++ b/recipes/use_lwrp.rb
@@ -1,0 +1,30 @@
+#
+# Cookbook Name:: prometheus
+# Recipe:: use_lwrp
+#
+# Author: Robert Berger <rberger@mist.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This recipe does nothing, allows you to `include_recipe "prometheus::use_lwrp"`
+# so you can override attributes and use the LWRP[s] in a wrapper cookbook.
+# Then `include_recipe "prometheus::default"` to actually install and configure prometheus.
+
+# New workflow:
+# - Create wrapper cookbook that
+#   - `include_recipe "prometheus::use_lwrp"
+#   - Collects any jobs / targets,
+#     - Use prometheus_job to create the jobs
+#   - Override any needed attributes
+#   - `include_recipe "prometheus::default`

--- a/templates/default/alertmanager.conf.erb
+++ b/templates/default/alertmanager.conf.erb
@@ -2,7 +2,12 @@ notification_config {
   name: "default"
 
 <% @notification_config.each do |name, config| %>
-  <%=  name %>: <%= config %> 
+  <%=  name %>: {
+  <% @config.each do |k, v| %> 
+    <%= k %>: "<%= v %>"
+  <% end %>
+
+  }
 <% end %>
 
 }

--- a/templates/default/alertmanager.conf.erb
+++ b/templates/default/alertmanager.conf.erb
@@ -1,12 +1,10 @@
 notification_config {
   name: "default"
-  hipchat_config: {
-    auth_token: "<%= node['prometheus']['alertmanager']['hipchat_auth_token'] %>"
-    room_id: <%= node['prometheus']['alertmanager']['hipchat_room_id'] %>
-  }
-  pagerduty_config: {
-    service_key: "<%= node['prometheus']['alertmanager']['pagerduty_service_key'] %>"
-  }
+
+<% @notification_config.each do |name, config| %>
+  <%=  name %>: <%= config %> 
+<% end %>
+
 }
 
 aggregation_rule {

--- a/templates/default/alertmanager.conf.erb
+++ b/templates/default/alertmanager.conf.erb
@@ -3,7 +3,7 @@ notification_config {
 
 <% @notification_config.each do |name, config| %>
   <%=  name %>: {
-  <% @config.each do |k, v| %> 
+  <% @notification_config[name].each do |k, v| %> 
     <%= k %>: "<%= v %>"
   <% end %>
 

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -14,5 +14,11 @@ scrape_configs:
   <% end %>
   metrics_path: "<%= job.metrics_path %>"
   target_groups:
-    - targets: <%= [job.target] %>
+    - targets: <%= job.target.kind_of?(String) ? [job.target] : job.target %>
+<% end %>
+
+<% if @rule_filenames %>
+rule_files:
+<% @rule_filenames.each do |filename| %>
+  - <%= filename %>
 <% end %>

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -17,6 +17,7 @@ scrape_configs:
     - targets: <%= job.target.kind_of?(String) ? [job.target] : job.target %>
 <% end %>
 
+<% Chef::Log.info "++++++++++ @rule_filenames: #{rule_filenames.inspect}" %>
 <% if @rule_filenames %>
 rule_files:
 <% @rule_filenames.each do |filename| %>

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -17,7 +17,7 @@ scrape_configs:
     - targets: <%= job.target.kind_of?(String) ? [job.target] : job.target %>
 <% end %>
 
-<% Chef::Log.info "++++++++++ @rule_filenames: #{rule_filenames.inspect}" %>
+<% Chef::Log.info "^^^^^^^^^^^ @rule_filenames: #{rule_filenames.inspect}" %>
 <% if @rule_filenames %>
 rule_files:
 <% @rule_filenames.each do |filename| %>

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -17,7 +17,6 @@ scrape_configs:
     - targets: <%= job.target.kind_of?(String) ? [job.target] : job.target %>
 <% end %>
 
-<% Chef::Log.info "^^^^^^^^^^^ @rule_filenames: #{@rule_filenames.inspect}" %>
 <% if @rule_filenames %>
 rule_files:
 <% @rule_filenames.each do |filename| %>

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -17,7 +17,7 @@ scrape_configs:
     - targets: <%= job.target.kind_of?(String) ? [job.target] : job.target %>
 <% end %>
 
-<% Chef::Log.info "^^^^^^^^^^^ @rule_filenames: #{rule_filenames.inspect}" %>
+<% Chef::Log.info "^^^^^^^^^^^ @rule_filenames: #{@rule_filenames.inspect}" %>
 <% if @rule_filenames %>
 rule_files:
 <% @rule_filenames.each do |filename| %>

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -22,3 +22,5 @@ rule_files:
 <% @rule_filenames.each do |filename| %>
   - <%= filename %>
 <% end %>
+<% end %>
+


### PR DESCRIPTION
- Fixed prometheus.yml.erb so you can pass a string or an array of strings to
- Added an empty use_lwrp recipe so you can `include_recipe prometheus::use_lwrp` in a wrapper cookbook
- Added an attribute `default['prometheus']['rule_filenames']` and modified prometheus.yml.erb so you can optionally add `rule_files`
- Updated README to reflect changes
