### PR TITLE
Deployment of Alertmanager from binary

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -207,6 +207,11 @@ end
 # Path to static asset directory, available at /user.
 default['prometheus']['flags']['web.user-assets']                                         = ''
 
+# Alertmanager attributes
+
+# Install method. Currently supports source and binary.
+default['prometheus']['alertmanager']['install_method']                                   = 'source'
+
 # Location of Alertmanager binary
 default['prometheus']['alertmanager']['binary']                                           = "#{node['prometheus']['dir']}/alertmanager"
 
@@ -220,8 +225,23 @@ default['prometheus']['alertmanager']['git_repository']                         
 # also be set to a branch or master.
 default['prometheus']['alertmanager']['git_revision']                                     = node['prometheus']['alertmanager']['version']
 
+# Location for Alertmanager pre-compiled binary.
+# Default for testing purposes
+default['prometheus']['alertmanager']['binary_url']                                       = 'https://github.com/prometheus/alertmanager/releases/download/0.0.4/alertmanager-0.0.4.linux-amd64.tar.gz'
+
+# Checksum for pre-compiled binary
+# Default for testing purposes
+default['prometheus']['alertmanager']['checksum']                                         = 'c41e819bef3accfe582c3eb8a50322c5ea73716fc1c55f968be7553618040810'
+
+# If file extension of your binary can not be determined by the URL
+# then define it here. Example 'tar.bz2'
+default['prometheus']['alertmanager']['file_extension']                                   = ''
+
 # Alertmanager configuration file name.
 default['prometheus']['alertmanager']['config.file']                                      = "#{node['prometheus']['dir']}/alertmanager.conf"
+
+# Alertmanager configuration storage directory
+default['prometheus']['alertmanager']['storage.path']                                     = "#{node['prometheus']['dir']}/data"
 
 # Alertmanager configuration chef template name.
 default['prometheus']['alertmanager']['config_cookbook_name']                             = 'prometheus'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ issues_url 'https://github.com/elijah/chef-prometheus/issues'
   supports os
 end
 
-depends 'apt'
+depends 'apt', '= 3.0.0' # any higher requires chef 12
 depends 'yum'
 depends 'build-essential'
 depends 'runit', '~> 1.5'

--- a/recipes/alertmanager.rb
+++ b/recipes/alertmanager.rb
@@ -56,23 +56,7 @@ end
 
 # -- Do the install -- #
 
-# These packages are needed go build
-%w(curl git-core mercurial gzip sed).each do |pkg|
-  package pkg
-end
-
-git "#{Chef::Config[:file_cache_path]}/alertmanager-#{node['prometheus']['alertmanager']['version']}" do
-  repository node['prometheus']['alertmanager']['git_repository']
-  revision node['prometheus']['alertmanager']['git_revision']
-  action :checkout
-end
-
-bash 'compile_alertmanager_source' do
-  cwd "#{Chef::Config[:file_cache_path]}/alertmanager-#{node['prometheus']['alertmanager']['version']}"
-  code "make && mv alertmanager #{node['prometheus']['dir']}"
-
-  notifies :restart, 'service[alertmanager]'
-end
+include_recipe "prometheus::alertmanager_#{node['prometheus']['alertmanager']['install_method']}"
 
 template '/etc/init/alertmanager.conf' do
   source 'upstart/alertmanager.service.erb'

--- a/recipes/alertmanager_binary.rb
+++ b/recipes/alertmanager_binary.rb
@@ -1,0 +1,39 @@
+#
+# Cookbook Name:: prometheus
+# Recipe:: alertmanager_binary
+#
+# Author: Javier Zunzunegui <javier.zunzunegui.b@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+include_recipe 'ark::default'
+
+%w(curl tar bzip2).each do |pkg|
+  package pkg
+end
+
+dir_name = ::File.basename(node['prometheus']['dir'])
+dir_path = ::File.dirname(node['prometheus']['dir'])
+
+ark dir_name do
+  url node['prometheus']['alertmanager']['binary_url']
+  checksum node['prometheus']['alertmanager']['checksum']
+  version node['prometheus']['alertmanager']['version']
+  prefix_root Chef::Config['file_cache_path']
+  path dir_path
+  owner node['prometheus']['user']
+  group node['prometheus']['group']
+  extension node['prometheus']['alertmanager']['file_extension'] unless node['prometheus']['alertmanager']['file_extension'].empty?
+  action :put
+end

--- a/recipes/alertmanager_source.rb
+++ b/recipes/alertmanager_source.rb
@@ -1,0 +1,36 @@
+#
+# Cookbook Name:: prometheus
+# Recipe:: alertmanager_source
+#
+# Author: Javier Zunzunegui <javier.zunzunegui.b@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# These packages are needed go build
+%w(curl git-core mercurial gzip sed).each do |pkg|
+  package pkg
+end
+
+git "#{Chef::Config[:file_cache_path]}/alertmanager-#{node['prometheus']['alertmanager']['version']}" do
+  repository node['prometheus']['alertmanager']['git_repository']
+  revision node['prometheus']['alertmanager']['git_revision']
+  action :checkout
+end
+
+bash 'compile_alertmanager_source' do
+  cwd "#{Chef::Config[:file_cache_path]}/alertmanager-#{node['prometheus']['alertmanager']['version']}"
+  code "make && mv alertmanager #{node['prometheus']['dir']}"
+
+  notifies :restart, 'service[alertmanager]'
+end

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -82,6 +82,6 @@ end
 
 # rubocop:disable Style/HashSyntax
 service 'prometheus' do
-  supports :status => true, :restart => true
+  supports :status => true, :restart => true, :reload => true
 end
 # rubocop:enable Style/HashSyntax

--- a/templates/default/upstart/alertmanager.service.erb
+++ b/templates/default/upstart/alertmanager.service.erb
@@ -10,5 +10,5 @@ setgid <%= node['prometheus']['user'] %>
 script
   exec >> "<%= node['prometheus']['log_dir'] %>/alertmanager.log"
   exec 2>&1
-  exec <%= node['prometheus']['alertmanager']['binary'] %> -config.file=<%= node['prometheus']['alertmanager']['config.file'] %>
+  exec <%= node['prometheus']['alertmanager']['binary'] %> -config.file=<%= node['prometheus']['alertmanager']['config.file'] %> -storage.path=<%= node['prometheus']['alertmanager']['storage.path'] %>
 end script


### PR DESCRIPTION
Allowing for deployment of alertmanager directly from binary, almost identical to how its being done in the default prometheus recipe. The 'source' deployment is left as default, but I found the binary more useful for deploying the beta versions https://github.com/prometheus/alertmanager/releases . 

Note moving away from 0.0.4 into the beta versions involves significant changes to the config (for starters, it's .yml), I am doing that by changing ['prometheus']['alermanager']['config_template_name'] and ...["config.file"] and running on the parent recipe:
template "/tmp/alertmanager.yml" do
    source 'alertmanager.yml.erb'
    mode 0644
end

Note also that alertmanager needs to run as root (['prometheus']['user'] and ['prometheus']['group'] must be root) otherwise has some issues with permissions. 
