### PR TITLE
New install method - shell_binary, upstart script tweak

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -12,7 +12,7 @@ default['prometheus']['binary']                                                 
 # Location of Prometheus pid file
 default['prometheus']['pid']                                                              = '/var/run/prometheus.pid'
 
-# Install method.  Currently supports source and binary.
+# Install method.  Currently supports source, binary and shell_binary.
 default['prometheus']['install_method']                                                   = 'binary'
 
 # Init style.

--- a/recipes/shell_binary.rb
+++ b/recipes/shell_binary.rb
@@ -1,0 +1,40 @@
+#
+# Cookbook Name:: prometheus
+# Recipe:: shell_binary
+#
+# Author: Rohit Gupta - @rohit01
+#
+# This recipie is similar to binary.rb without 'ark' dependency
+#
+
+%w(curl tar bzip2).each do |pkg|
+  package pkg
+end
+
+bash 'download_prometheus' do
+  code <<-EOH
+    pfilename="#{Chef::Config[:file_cache_path]}/prometheus-#{node['prometheus']['version']}.tar.gz"
+    curl -L -o "${pfilename}" "#{node['prometheus']['binary_url']}"
+    chksum="$(shasum -b -a 256 ${pfilename} | awk '{print $1}')"
+    if [ "${chksum}" != "#{node['prometheus']['checksum']}" ]; then
+      echo "ERROR: Downloaded file checksum mismatch. Aborting!"
+      exit 1
+    fi
+  EOH
+  user     'root'
+  group    'root'
+  creates  "#{Chef::Config[:file_cache_path]}/prometheus-#{node['prometheus']['version']}.tar.gz"
+  action   :run
+  notifies :run, 'bash[install_prometheus]', :immediately
+end
+
+bash 'install_prometheus' do
+  code <<-EOH
+    mkdir -p "#{node['prometheus']['dir']}"
+    tar -xzf "#{Chef::Config[:file_cache_path]}/prometheus-#{node['prometheus']['version']}.tar.gz" -C "#{node['prometheus']['dir']}" --strip-components=1
+  EOH
+  user     'root'
+  group    'root'
+  action   :nothing
+  notifies :restart, 'service[prometheus]'
+end

--- a/templates/default/upstart/prometheus.service.erb
+++ b/templates/default/upstart/prometheus.service.erb
@@ -8,6 +8,7 @@ setuid <%= node['prometheus']['user'] %>
 setgid <%= node['prometheus']['user'] %>
 
 script
+  chdir <%= node['prometheus']['dir'] %>
   exec >> "<%= node['prometheus']['log_dir'] %>/prometheus.log"
   exec 2>&1
   exec <%= node['prometheus']['binary'] %> <%= generate_flags %>


### PR DESCRIPTION
Changes:
- New install method - shell_binary: Faced problems with ark dependency with the binary module on ubuntu 14.04. The new module aims to provide same functionality using basic curl and shell.
- Upstart script tweak: Console template does not work as it tries to search for console pages in root (/). The default should be the installation directory of prometheus. This is where the consoles/ directory is present.

Thanks!
