### PR TITLE
Bump Berkshelf to 4.0.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :unit do
-  gem 'berkshelf', '~> 3.2.0'
+  gem 'berkshelf', '~> 4.0.1'
   gem 'chefspec',  '~> 4.1.0'
 end
 


### PR DESCRIPTION
- should address the issue of failing tests because of Faraday/gzip
  response issue -> https://github.com/berkshelf/berkshelf/issues/1466