### PR TITLE
Fix Prometheus for newer versions

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -190,7 +190,11 @@ default['prometheus']['flags']['web.listen-address']                            
 default['prometheus']['flags']['web.telemetry-path']                                      = '/metrics'
 
 # Read assets/templates from file instead of binary.
-default['prometheus']['flags']['web.use-local-assets']                                    = false
+# web.use-local-assets flag got removed in 0.17
+# https://github.com/prometheus/prometheus/commit/a542cc86096e1bad694e04d307301a807583dfc6
+if Gem::Version.new(node['prometheus']['version']) <= Gem::Version.new('0.16.2')
+  default['prometheus']['flags']['web.use-local-assets']                                  = false
+end
 
 # Path to static asset directory, available at /user.
 default['prometheus']['flags']['web.user-assets']                                         = ''


### PR DESCRIPTION
- Prometheus has removed `web.use-local-assets` in version 0.17