### PR TITLE
Use chef's native accumulators

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,23 +3,19 @@ driver:
 
 provisioner:
   name: chef_zero
-  require_chef_omnibus: 12.0.3
   data_path: test/shared
 
 platforms:
   - name: ubuntu-14.04
-    run_list:
-      - recipe[apt]
-  - name: ubuntu-12.04
-    run_list:
-      - recipe[apt]
-  - name: debian-7.7
-    run_list:
-      - recipe[apt]
-  - name: centos-6.6
+  - name: ubuntu-16.04
+  - name: debian-7.9
+    driver:
+      cache_directory: false
+  - name: debian-8.7
+  - name: centos-6.8
     run_list:
       - recipe[yum::default]
-  - name: centos-7.0
+  - name: centos-7.3
     run_list:
       - recipe[yum::default]
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,3 +25,5 @@ Style/ExtraSpacing:
   Enabled: false
 Style/SpaceBeforeFirstArg:
   Enabled: false
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,14 +19,12 @@ default['prometheus']['install_method']                                         
 # rubocop:disable Style/ConditionalAssignment
 case node['platform_family']
 when 'debian'
-  if node['platform'] == 'ubuntu'
-    if node['platform_version'].to_f < 15.04
-      default['prometheus']['init_style']                                                 = 'upstart'
-    else
-      default['prometheus']['init_style']                                                 = 'systemd'
-    end
+  if node['platform'] == 'ubuntu' && node['platform_version'].to_f < 15.04
+    default['prometheus']['init_style'] = 'upstart'
+  elsif node['platform'] == 'debian' && node['platform_version'].to_f < 8.0
+    default['prometheus']['init_style'] = 'runit'
   else
-    default['prometheus']['init_style']                                                   = 'runit'
+    default['prometheus']['init_style'] = 'systemd'
   end
 when 'rhel', 'fedora'
   if node['platform_version'].to_i >= 7
@@ -50,7 +48,7 @@ default['prometheus']['source']['git_repository']                               
 
 # Prometheus source repository git reference.  Defaults to version tag.  Can
 # also be set to a branch or master.
-default['prometheus']['source']['git_revision']                                           = node['prometheus']['version']
+default['prometheus']['source']['git_revision']                                           = "v#{node['prometheus']['version']}"
 
 # System user to use
 default['prometheus']['user']                                                             = 'prometheus'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -61,7 +61,7 @@ default['prometheus']['use_existing_user']                                      
 
 # Location for Prometheus pre-compiled binary.
 # Default for testing purposes
-default['prometheus']['binary_url']                                                       = 'https://github.com/prometheus/prometheus/releases/download/v1.3.1/prometheus-1.3.1.linux-amd64.tar.gz'
+default['prometheus']['binary_url']                                                       = "https://github.com/prometheus/prometheus/releases/download/v#{node['prometheus']['version']}/prometheus-#{node['prometheus']['version']}.linux-amd64.tar.gz"
 
 # Checksum for pre-compiled binary
 # Default for testing purposes

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,16 +7,16 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.6.3'
 source_url 'https://github.com/elijah/chef-prometheus'
 issues_url 'https://github.com/elijah/chef-prometheus/issues'
+chef_version '>= 12.15.25'
 
 %w(ubuntu debian centos redhat fedora).each do |os|
   supports os
 end
 
-depends 'apt'
 depends 'yum'
 depends 'build-essential'
 depends 'runit', '~> 1.5'
 depends 'bluepill', '~> 2.3'
-depends 'accumulator'
 depends 'ark'
 depends 'golang'
+depends 'compat_resource'

--- a/providers/job.rb
+++ b/providers/job.rb
@@ -1,7 +1,0 @@
-use_inline_resources
-
-action :create do
-end
-
-action :delete do
-end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -33,6 +33,7 @@ end
 
 bash 'compile_prometheus_source' do
   cwd "#{Chef::Config[:file_cache_path]}/prometheus-#{node['prometheus']['version']}"
+  environment 'PATH' => "/usr/local/go/bin:#{ENV['PATH']}"
   code <<-EOH
     make build &&
     mv prometheus #{node['prometheus']['dir']} &&

--- a/resources/job.rb
+++ b/resources/job.rb
@@ -1,8 +1,30 @@
-default_action :create
-actions :delete
+property :name,                String, name_property: true, required: true
+property :scrape_interval,     String
+property :scrape_timeout,      String
+property :target,              [Array, String]
+property :metrics_path,        String, default: '/metrics'
+property :config_file,         String, default: lazy { node['prometheus']['flags']['config.file'] }
+property :source, String, default: 'prometheus'
 
-attribute :name,                kind_of: String, name_attribute: true, required: true
-attribute :scrape_interval,     kind_of: String
-attribute :scrape_timeout,      kind_of: String
-attribute :target,              kind_of: [Array, String]
-attribute :metrics_path,        kind_of: String, default: '/metrics'
+action :create do
+  with_run_context :root do
+    edit_resource(:template, config_file) do |new_resource|
+      cookbook new_resource.source
+      variables[:jobs] ||= {}
+      variables[:jobs][new_resource.name] ||= {}
+      variables[:jobs][new_resource.name]['scrape_interval'] = new_resource.scrape_interval
+      variables[:jobs][new_resource.name]['scrape_timeout'] = new_resource.scrape_timeout
+      variables[:jobs][new_resource.name]['target'] = new_resource.target
+      variables[:jobs][new_resource.name]['metrics_path'] = new_resource.metrics_path
+
+      action :nothing
+      delayed_action :create
+    end
+  end
+end
+
+action :delete do
+  template config_file do
+    action :delete
+  end
+end

--- a/templates/default/debian/default/prometheus.erb
+++ b/templates/default/debian/default/prometheus.erb
@@ -1,0 +1,3 @@
+# Configuration file for the prometheus service
+
+GOMAXPROCS=<%= node['cpu']['total'] %>

--- a/templates/default/prometheus.yml.erb
+++ b/templates/default/prometheus.yml.erb
@@ -4,17 +4,17 @@ global:
   evaluation_interval: "15s" # By default, evaluate rules every 15 seconds.
 
 scrape_configs:
-<% for job in @jobs||[] %>
-- job_name: "<%= job.name %>"
-  <% if job.scrape_interval %>
-  scrape_interval: "<%= job.scrape_interval %>"
+<% @jobs.each do |name, job| %>
+- job_name: "<%= name %>"
+  <% if job['scrape_interval'] %>
+  scrape_interval: "<%= job['scrape_interval'] %>"
   <% end %>
-  <% if job.scrape_timeout %>
-  scrape_timeout: "<%= job.scrape_timeout %>"
+  <% if job['scrape_timeout'] %>
+  scrape_timeout: "<%= job['scrape_timeout'] %>"
   <% end %>
-  metrics_path: "<%= job.metrics_path %>"
+  metrics_path: "<%= job['metrics_path'] %>"
   static_configs:
-    - targets: <%= job.target.kind_of?(String) ? [job.target] : job.target %>
+    - targets: <%=  Array(job['target']) %>
 <% end %>
 
 <% if @rule_filenames %>


### PR DESCRIPTION
Also:
 * update to latest centos/debian/ubuntu boxes
 * fix systemd support on debian/ubuntu
 * install prometheus before configuring (Fixes: #68)

This gets source installs a little further by correctly getting the tag and (at least on debian) setting the path to `go` correctly, but the GOPATH is still unset and I'm not planning on using source installs.

The accumulator cookbook is unlikely to ever work on Chef 13, so this PR removes it's usage and uses the built in accumulators that are present from Chef 12.15 onwards.