### PR TITLE
Use basename $0 as name in init.d scripts

### DIFF
--- a/templates/centos/prometheus.erb
+++ b/templates/centos/prometheus.erb
@@ -18,7 +18,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 export PATH
 
-name=prometheus
+name=$(basename $0)
 program="<%= node['prometheus']['binary'] %>"
 args="<%= generate_flags %>"
 pidfile=<%= node['prometheus']['pid'] %>

--- a/templates/debian/prometheus.erb
+++ b/templates/debian/prometheus.erb
@@ -18,7 +18,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 export PATH
 
-name=prometheus
+name=$(basename $0)
 program="<%= node['prometheus']['binary'] %>"
 args="<%= generate_flags %>"
 pidfile=<%= node['prometheus']['pid'] %>

--- a/templates/ubuntu/prometheus.erb
+++ b/templates/ubuntu/prometheus.erb
@@ -18,7 +18,7 @@
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 export PATH
 
-name=prometheus
+name=$(basename $0)
 program="<%= node['prometheus']['binary'] %>"
 args="<%= generate_flags %>"
 pidfile=<%= node['prometheus']['pid'] %>


### PR DESCRIPTION
This will allow to more easilly run multiple
prometheus instances at once. Which will
make more sense now that there is support
for federation.