### PR TITLE
dont specify apt version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ chef_version '>= 12.15.25' if respond_to?(:chef_version)
   supports os
 end
 
-depends 'apt', '= 3.0.0' # any higher requires chef 12
+depends 'apt'
 depends 'yum'
 depends 'build-essential'
 depends 'runit', '~> 1.5'


### PR DESCRIPTION
other cookbooks specify a higher version of apt than 3.0.0. Being so strict about the version causes conflicts. You are requiring chef to be >= 12.15, so perhaps the low apt dependency is unnecessary now?