### PR TITLE
Alertmanager: Templatize config, user, and url.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,3 +27,9 @@ Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Lint/AmbiguousBlockAssociation:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -100,7 +100,7 @@ default['prometheus']['flags']["alertmanager.#{timeout_flag}"]                  
 default['prometheus']['flags']['alertmanager.notification-queue-capacity']                = 100
 
 # The URL of the alert manager to send notifications to.
-default['prometheus']['flags']['alertmanager.url']                                        = ''
+default['prometheus']['flags']['alertmanager.url']                                        = 'http://127.0.0.1/alert-manager/'
 
 # Maximum number of queries executed concurrently.
 default['prometheus']['flags']['query.max-concurrency']                                   = 20

--- a/spec/unit/recipes/alertmanager_spec.rb
+++ b/spec/unit/recipes/alertmanager_spec.rb
@@ -1,0 +1,300 @@
+#
+# Filename:: alertmanager_spec.rb
+# Description:: Verifies alertmanager recipe(s).
+#
+# Author: Elijah Caine <elijah.caine.mv@gmail.com>
+#
+
+require 'spec_helper'
+
+# Caution: This is a carbon-copy of default_spec.rb with some variable replacements.
+
+# rubocop:disable Metrics/BlockLength
+describe 'prometheus::alertmanager' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/tmp/chef/cache').converge(described_recipe)
+  end
+
+  before do
+    stub_command('/usr/local/go/bin/go version | grep "go1.5 "').and_return(0)
+  end
+
+  it 'creates a user with correct attributes' do
+    expect(chef_run).to create_user('prometheus').with(
+      system: true,
+      shell: '/bin/false',
+      home: '/opt/prometheus'
+    )
+  end
+
+  it 'creates a directory at /opt/prometheus' do
+    expect(chef_run).to create_directory('/opt/prometheus').with(
+      owner: 'prometheus',
+      group: 'prometheus',
+      mode: '0755',
+      recursive: true
+    )
+  end
+
+  it 'creates a directory at /var/log/prometheus' do
+    expect(chef_run).to create_directory('/var/log/prometheus').with(
+      owner: 'prometheus',
+      group: 'prometheus',
+      mode: '0755',
+      recursive: true
+    )
+  end
+
+  it 'renders a prometheus job configuration file and notifies prometheus to restart' do
+    resource = chef_run.template('/opt/prometheus/alertmanager.conf')
+    expect(resource).to notify('service[alertmanager]').to(:restart)
+  end
+
+  # Test for source.rb
+
+  context 'source' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+        node.set['prometheus']['alertmanager']['version'] = '0.6.2'
+        node.set['prometheus']['alertmanager']['install_method'] = 'source'
+      end.converge(described_recipe)
+    end
+
+    it 'includes build-essential' do
+      expect(chef_run).to include_recipe('build-essential::default')
+    end
+
+    %w(curl git-core mercurial gzip sed).each do |pkg|
+      it 'installs #{pkg}' do
+        expect(chef_run).to install_package(pkg)
+      end
+    end
+
+    it 'checks out alertmanager from github' do
+      expect(chef_run).to checkout_git("#{Chef::Config[:file_cache_path]}/alertmanager-0.6.2").with(
+        repository: 'https://github.com/prometheus/alertmanager.git',
+        revision: '0.6.2'
+      )
+    end
+
+    it 'compiles alertmanager source' do
+      expect(chef_run).to run_bash('compile_alertmanager_source')
+    end
+
+    it 'notifies alertmanager to restart' do
+      resource = chef_run.bash('compile_alertmanager_source')
+      expect(resource).to notify('service[alertmanager]').to(:restart)
+    end
+
+    context 'runit' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'runit'
+        end.converge(described_recipe)
+      end
+
+      it 'includes runit::default recipe' do
+        expect(chef_run).to include_recipe('runit::default')
+      end
+
+      it 'enables runit_service' do
+        expect(chef_run).to enable_runit_service('alertmanager')
+      end
+    end
+
+    context 'bluepill' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'bluepill'
+        end.converge(described_recipe)
+      end
+
+      it 'includes bluepill::default recipe' do
+        expect(chef_run).to include_recipe('bluepill::default')
+      end
+
+      it 'renders a bluepill configuration file' do
+        expect(chef_run).to render_file("#{chef_run.node['bluepill']['conf_dir']}/alertmanager.pill")
+      end
+    end
+
+    context 'init' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'init'
+        end.converge(described_recipe)
+      end
+
+      it 'renders an init.d configuration file' do
+        expect(chef_run).to render_file('/etc/init.d/alertmanager')
+      end
+    end
+
+    context 'systemd' do
+      unit_file = '/etc/systemd/system/alertmanager.service'
+
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'systemd'
+          node.set['prometheus']['user'] = 'prom_user'
+          node.set['prometheus']['group'] = 'prom_group'
+          node.set['prometheus']['alertmanager']['binary'] = '/tmp/alertmanager'
+          node.set['prometheus']['alertmanager']['storage.path'] = '/tmp/alertmanager_data'
+          node.set['prometheus']['alertmanager']['config.file'] = '/tmp/alertmanager.conf'
+          node.set['prometheus']['flags']['alertmanager.url'] = 'http://0.0.0.0:8080'
+        end.converge(described_recipe)
+      end
+
+      it 'renders a systemd service file' do
+        expect(chef_run).to render_file(unit_file)
+      end
+
+      it 'renders systemd unit with custom variables' do
+        expect(chef_run).to render_file(unit_file).with_content { |content|
+          expect(content).to include('ExecStart=/tmp/alertmanager')
+          expect(content).to include('-storage.path=/tmp/alertmanager_data \\')
+          expect(content).to include('-config.file=/tmp/alertmanager.conf \\')
+          expect(content).to include('-web.external-url=http://0.0.0.0:8080')
+          expect(content).to include('User=prom_user')
+          expect(content).to include('Group=prom_group')
+        }
+      end
+    end
+
+    context 'upstart' do
+      job_file = '/etc/init/alertmanager.conf'
+
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'upstart'
+          node.set['prometheus']['user'] = 'prom_user'
+          node.set['prometheus']['group'] = 'prom_group'
+          node.set['prometheus']['alertmanager']['binary'] = '/tmp/alertmanager'
+          node.set['prometheus']['alertmanager']['storage.path'] = '/tmp/alertmanager_data'
+          node.set['prometheus']['alertmanager']['config.file'] = '/tmp/alertmanager.conf'
+          node.set['prometheus']['flags']['alertmanager.url'] = 'http://0.0.0.0:8080'
+          node.set['prometheus']['log_dir'] = '/tmp'
+        end.converge(described_recipe)
+      end
+
+      it 'renders an upstart job configuration file' do
+        expect(chef_run).to render_file(job_file)
+      end
+
+      it 'renders an upstart job configuration with custom variables' do
+        expect(chef_run).to render_file(job_file).with_content { |content|
+          expect(content).to include('setuid prom_user')
+          expect(content).to include('setgid prom_group')
+          expect(content).to include('exec >> "/tmp/alertmanager.log"')
+          expect(content).to include('exec /tmp/alertmanager')
+          expect(content).to include('-storage.path=/tmp/alertmanager_data')
+          expect(content).to include('-config.file=/tmp/alertmanager.conf')
+          expect(content).to include('-web.external-url=http://0.0.0.0:8080')
+        }
+      end
+    end
+  end
+
+  # Test for binary.rb
+
+  context 'binary' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+        node.set['prometheus']['alertmanager']['version'] = '0.6.2'
+        node.set['prometheus']['alertmanager']['install_method'] = 'binary'
+      end.converge(described_recipe)
+    end
+
+    it 'runs ark with correct attributes' do
+      expect(chef_run).to put_ark('prometheus').with(
+        url: 'https://github.com/prometheus/alertmanager/releases/download/v0.6.2/alertmanager-0.6.2.linux-amd64.tar.gz',
+        checksum: '8b796592b974a1aa51cac4e087071794989ecc957d4e90025d437b4f7cad214a',
+        version: '0.6.2',
+        prefix_root: Chef::Config['file_cache_path'],
+        path: '/opt',
+        owner: 'prometheus',
+        group: 'prometheus'
+      )
+    end
+
+    it 'runs ark with given file_extension' do
+      chef_run.node.set['prometheus']['alertmanager']['file_extension'] = 'tar.gz'
+      chef_run.converge(described_recipe)
+      expect(chef_run).to put_ark('prometheus').with(
+        extension: 'tar.gz'
+      )
+    end
+
+    context 'runit' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'runit'
+          node.set['prometheus']['alertmanager']['install_method'] = 'binary'
+        end.converge(described_recipe)
+      end
+
+      it 'includes runit::default recipe' do
+        expect(chef_run).to include_recipe('runit::default')
+      end
+
+      it 'enables runit_service' do
+        expect(chef_run).to enable_runit_service('alertmanager')
+      end
+    end
+
+    context 'bluepill' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'bluepill'
+          node.set['prometheus']['alertmanager']['install_method'] = 'binary'
+        end.converge(described_recipe)
+      end
+
+      it 'includes bluepill::default recipe' do
+        expect(chef_run).to include_recipe('bluepill::default')
+      end
+
+      it 'renders a bluepill configuration file' do
+        expect(chef_run).to render_file("#{chef_run.node['bluepill']['conf_dir']}/alertmanager.pill")
+      end
+    end
+
+    context 'init' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'init'
+          node.set['prometheus']['alertmanager']['install_method'] = 'binary'
+        end.converge(described_recipe)
+      end
+
+      it 'renders an init.d configuration file' do
+        expect(chef_run).to render_file('/etc/init.d/alertmanager')
+      end
+    end
+
+    context 'systemd' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'systemd'
+          node.set['prometheus']['alertmanager']['install_method'] = 'binary'
+        end.converge(described_recipe)
+      end
+
+      it 'renders a systemd service file' do
+        expect(chef_run).to render_file('/etc/systemd/system/alertmanager.service')
+      end
+    end
+    context 'upstart' do
+      let(:chef_run) do
+        ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04', file_cache_path: '/var/chef/cache') do |node|
+          node.set['prometheus']['init_style'] = 'upstart'
+          node.set['prometheus']['alertmanager']['install_method'] = 'binary'
+        end.converge(described_recipe)
+      end
+
+      it 'renders an upstart job configuration file' do
+        expect(chef_run).to render_file('/etc/init/alertmanager.conf')
+      end
+    end
+  end
+end

--- a/templates/default/alertmanager.pill.erb
+++ b/templates/default/alertmanager.pill.erb
@@ -5,8 +5,8 @@ Bluepill.application('alertmanager') do |app|
     process.working_dir = "<%= node['prometheus']['dir'] %>"
     process.start_command = "<%= node['prometheus']['alertmanager']['binary'] %> -log.level=debug \
         -storage.path="<%= node['prometheus']['dir'] %>/data" \
-        -config.file=/opt/prometheus/alertmanager.conf \
-        -web.external-url=http://127.0.0.1/alert-manager/
+        -config.file="<%= node['prometheus']['alertmanager']['config.file'] %>" \
+        -web.external-url="<%= node['prometheus']['flags']['alertmanager.url'] %>"
     process.environment = {'GOMAXPROCS' => <%= node['cpu']['total'] %>}
     process.stdout = process.stderr = "<%= node['prometheus']['log_dir'] %>/alertmanager.log"
     process.daemonize = true

--- a/templates/default/systemd/alertmanager.service.erb
+++ b/templates/default/systemd/alertmanager.service.erb
@@ -1,14 +1,16 @@
 [Unit]
-Description=Prometheus Alert Manager
+Description=Prometheus Alertmanager
 After=network.target
 
 [Service]
 ExecStart=<%= node['prometheus']['alertmanager']['binary'] %> \
     -log.level=debug \
-    -storage.path="<%= node['prometheus']['dir'] %>/data" \
-    -config.file=/opt/prometheus/alertmanager.conf \
-    -web.external-url=http://127.0.0.1/alert-manager/
-User=prometheus
+    -storage.path=<%= node['prometheus']['alertmanager']['storage.path'] %> \
+    -config.file=<%=  node['prometheus']['alertmanager']['config.file'] %> \
+    -web.external-url=<%= node['prometheus']['flags']['alertmanager.url'] %>
+User=<%= node['prometheus']['user'] %>
+Group=<%= node['prometheus']['group'] %>
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/default/upstart/alertmanager.service.erb
+++ b/templates/default/upstart/alertmanager.service.erb
@@ -5,10 +5,10 @@ stop on runlevel [016]
 respawn
 env GOMAXPROCS=<%= node['cpu']['total'] %>
 setuid <%= node['prometheus']['user'] %>
-setgid <%= node['prometheus']['user'] %>
+setgid <%= node['prometheus']['group'] %>
 
 script
   exec >> "<%= node['prometheus']['log_dir'] %>/alertmanager.log"
   exec 2>&1
-  exec <%= node['prometheus']['alertmanager']['binary'] %> -config.file=<%= node['prometheus']['alertmanager']['config.file'] %> -storage.path=<%= node['prometheus']['alertmanager']['storage.path'] %>
+  exec <%= node['prometheus']['alertmanager']['binary'] %> -config.file=<%= node['prometheus']['alertmanager']['config.file'] %> -storage.path=<%= node['prometheus']['alertmanager']['storage.path'] %> -web.external-url=<%= node['prometheus']['flags']['alertmanager.url'] %>
 end script

--- a/test/integration/alertmanager/serverspec/default_spec.rb
+++ b/test/integration/alertmanager/serverspec/default_spec.rb
@@ -1,0 +1,17 @@
+require_relative '../../../kitchen/data/spec_helper'
+
+describe 'alertmanager service' do
+  describe service('alertmanager') do
+    it { should be_running }
+  end
+
+  describe port(9093) do
+    it { should be_listening.with('tcp') }
+  end
+end
+
+describe 'alertmanger should be exposing metrics' do
+  describe command("curl 'http://localhost:9093/#/alerts/'") do
+    its(:stdout) { should include('<title>Alertmanager</title>') }
+  end
+end


### PR DESCRIPTION
@mburns @elijah (at any other maintainers)

This Pull Request adds the ability to template the http url, config destination, and user of the alert manager service(s).

Let me know if there's any edits I should make before it can be merged -- or if there are any fundamental problems with it being added in the first place. Like maybe we should add tests. Tests are cool. 😄 