### PR TITLE
resources/job: respect allow_external_config flag

### DIFF
--- a/resources/job.rb
+++ b/resources/job.rb
@@ -21,6 +21,8 @@ action :create do
 
       action :nothing
       delayed_action :create
+
+      not_if { node['prometheus']['allow_external_config'] }
     end
   end
 end


### PR DESCRIPTION
@elijah There the `allow_external_config` flag's behavior was deprecated but the flag was not removed. I figure the removal was an accident so this adds it back in.

I tried adding a test for this in the future but I'm not sure the best way to go about it, chefspec doesn't like asking if the `prometheus_job` resource has created a template. Let me know if you've got any ideas.