### PR TITLE
Alertmanager.rb: service typo correction

### DIFF
--- a/recipes/alertmanager.rb
+++ b/recipes/alertmanager.rb
@@ -104,7 +104,7 @@ when 'systemd'
     notifies :restart, 'service[alertmanager]', :delayed
   end
 
-  service 'prometheus' do
+  service 'alertmanager' do
     supports :status => true, :restart => true
     action [:enable, :start]
   end


### PR DESCRIPTION
service 'prometheus' -> service 'alertmanager'

I'm pretty sure this was a typo to begin with.

@elijah 