### PR TITLE
add v2 cli opts of storage retention

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -163,6 +163,7 @@ default['prometheus']['flags']['storage.local.pedantic-checks']                 
 
 # How long to retain samples in the local storage.
 default['prometheus']['flags']['storage.local.retention']                                 = '360h0m0s'
+default['prometheus']['v2_cli_opts']['storage.tsdb.retention']                            = '15d'
 
 # When to sync series files after modification. Possible values:
 # 'never', 'always', 'adaptive'. Sync'ing slows down storage performance


### PR DESCRIPTION
Since the attribute of `v2 cli opts of storage retention` did not exist, it was added.

ref: https://prometheus.io/docs/prometheus/latest/storage/#operational-aspects